### PR TITLE
Fix code scanning alert no. 74: Database query built from user-controlled sources

### DIFF
--- a/src/user-module/user.service.ts
+++ b/src/user-module/user.service.ts
@@ -21,13 +21,25 @@ export class UserService {
   }
 
   async update(updateUserDto: UpdateUserDto): Promise<IUser> {
+    const updateData = this.sanitizeUpdateData(updateUserDto);
     const updatedUser = await this.userModel.findByIdAndUpdate(
       updateUserDto.id,
-      { ...updateUserDto },
+      { $set: updateData },
       { new: true },
     );
 
     return UserTransformer.transformerToUser(updatedUser);
+  }
+
+  private sanitizeUpdateData(updateUserDto: UpdateUserDto): Partial<UpdateUserDto> {
+    const allowedFields = ['name', 'email', 'password']; // Add all allowed fields here
+    const sanitizedData: Partial<UpdateUserDto> = {};
+    for (const key of allowedFields) {
+      if (key in updateUserDto) {
+        sanitizedData[key] = updateUserDto[key];
+      }
+    }
+    return sanitizedData;
   }
 
   async getUsers(): Promise<IUser[]> {


### PR DESCRIPTION
Fixes [https://github.com/Verdent-Sphere-Thiha-Zaw/thz_user_service_API/security/code-scanning/74](https://github.com/Verdent-Sphere-Thiha-Zaw/thz_user_service_API/security/code-scanning/74)

To fix the problem, we need to ensure that the user-provided data in `updateUserDto` is sanitized before being used in the query. We can achieve this by using the `$set` operator in the update query to ensure that the data is treated as literal values. Additionally, we should validate the `updateUserDto` object to ensure it only contains expected fields.

1. Modify the `update` method in `UserService` to use the `$set` operator.
2. Add validation to ensure `updateUserDto` only contains expected fields.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
