### PR TITLE
Fix code scanning alert no. 197: Database query built from user-controlled sources

### DIFF
--- a/src/user-module/user.service.ts
+++ b/src/user-module/user.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { User } from './schema/user.schema';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 import { CreateUserDto, UpdateUserDto } from './dto';
 import { IUser } from 'src/common';
 import { UserTransformer } from './transformer';
@@ -21,9 +21,12 @@ export class UserService {
   }
 
   async update(updateUserDto: UpdateUserDto): Promise<IUser> {
+    if (!Types.ObjectId.isValid(updateUserDto.id)) {
+      throw new Error('Invalid user ID');
+    }
     const updateData = this.sanitizeUpdateData(updateUserDto);
     const updatedUser = await this.userModel.findByIdAndUpdate(
-      updateUserDto.id,
+      { _id: { $eq: updateUserDto.id } },
       { $set: updateData },
       { new: true },
     );


### PR DESCRIPTION
Fixes [https://github.com/Verdent-Sphere-Thiha-Zaw/thz_user_service_API/security/code-scanning/197](https://github.com/Verdent-Sphere-Thiha-Zaw/thz_user_service_API/security/code-scanning/197)

To fix the problem, we need to ensure that the `updateUserDto.id` is properly sanitized before being used in the `findByIdAndUpdate` query. We can achieve this by using the `$eq` operator to ensure that the user input is interpreted as a literal value. Additionally, we can validate that the `id` is a valid MongoDB ObjectId.

1. Modify the `update` method in `user.service.ts` to use the `$eq` operator for the `id` field.
2. Add validation to ensure that the `id` is a valid MongoDB ObjectId.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
